### PR TITLE
Modify country filtering because v2 is deprecated

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     </p>
     <p><i>Click the headers to sort the table. (Data sources:
             <a target="_blank"
-                href="https://corona.lmao.ninja/countries?sort=country">https://corona.lmao.ninja/countries?sort=country</a>)
+                href="https://corona.lmao.ninja/v3/covid-19/countries/country">https://corona.lmao.ninja/v3/covid-19/countries/country</a>)
         </i>
     </p>
     <p>


### PR DESCRIPTION
# Changed log

- When using the `https://corona.lmao.ninja/countries?sort=tawan` it will get following response:

```JSON
{"message":"This endpoint has been deprecated. Use /v3/covid-19/countries instead.","docs":"http://corona.lmao.ninja/docs"}
```

And it should use `https://corona.lmao.ninja/v3/covid-19/countries/taiwan` instead :).